### PR TITLE
Replace StatusCode+ParseError+Result with RunResult

### DIFF
--- a/example/improve_java.py
+++ b/example/improve_java.py
@@ -5,7 +5,7 @@ import sys
 import random
 import argparse
 import os
-from pyggi.base import Patch, ParseError, AbstractProgram
+from pyggi.base import Patch, AbstractProgram
 from pyggi.line import LineProgram
 from pyggi.line import LineReplacement, LineInsertion, LineDeletion
 from pyggi.tree import TreeProgram, XmlEngine
@@ -13,16 +13,16 @@ from pyggi.tree import StmtReplacement, StmtInsertion, StmtDeletion
 from pyggi.algorithms import LocalSearch
 
 class MyProgram(AbstractProgram):
-    def compute_fitness(self, elapsed_time, stdout, stderr):
+    def compute_fitness(self, result, return_code, stdout, stderr, elapsed_time):
         try:
             runtime, pass_all = stdout.strip().split(',')
             runtime = float(runtime)
             if not pass_all == 'true':
-                raise ParseError
+                result.status = 'PARSE_ERROR'
             else:
-                return runtime
+                result.fitness = runtime
         except:
-            raise ParseError
+            result.status = 'PARSE_ERROR'
 
 class MyLineProgram(LineProgram, MyProgram):
     pass

--- a/example/improve_python.py
+++ b/example/improve_python.py
@@ -4,7 +4,7 @@ Improving non-functional properties ::
 import sys
 import random
 import argparse
-from pyggi.base import Patch, ParseError, AbstractProgram
+from pyggi.base import Patch, AbstractProgram
 from pyggi.line import LineProgram
 from pyggi.line import LineReplacement, LineInsertion, LineDeletion
 from pyggi.tree import TreeProgram
@@ -12,7 +12,7 @@ from pyggi.tree import StmtReplacement, StmtInsertion, StmtDeletion
 from pyggi.algorithms import LocalSearch
 
 class MyProgram(AbstractProgram):
-    def compute_fitness(self, elapsed_time, stdout, stderr):
+    def compute_fitness(self, result, return_code, stdout, stderr, elapsed_time):
         import re
         m = re.findall("runtime: ([0-9.]+)", stdout)
         if len(m) > 0:
@@ -20,11 +20,11 @@ class MyProgram(AbstractProgram):
             failed = re.findall("([0-9]+) failed", stdout)
             pass_all = len(failed) == 0
             if pass_all:
-                return round(float(runtime), 3)
+                result.fitness = round(float(runtime), 3)
             else:
-                raise ParseError
+                result.status = 'PARSE_ERROR'
         else:
-            raise ParseError
+            result.status = 'PARSE_ERROR'
 
 class MyLineProgram(LineProgram, MyProgram):
     pass

--- a/example/repair_python.py
+++ b/example/repair_python.py
@@ -4,7 +4,7 @@ Automated program repair ::
 import sys
 import random
 import argparse
-from pyggi.base import Patch, ParseError, AbstractProgram
+from pyggi.base import Patch, AbstractProgram
 from pyggi.line import LineProgram
 from pyggi.line import LineReplacement, LineInsertion, LineDeletion
 from pyggi.tree import TreeProgram
@@ -12,7 +12,7 @@ from pyggi.tree import StmtReplacement, StmtInsertion, StmtDeletion
 from pyggi.algorithms import LocalSearch
 
 class MyProgram(AbstractProgram):
-    def compute_fitness(self, elapsed_time, stdout, stderr):
+    def compute_fitness(self, result, return_code, stdout, stderr, elapsed_time):
         import re
         m = re.findall("runtime: ([0-9.]+)", stdout)
         if len(m) > 0:
@@ -20,9 +20,9 @@ class MyProgram(AbstractProgram):
             failed = re.findall("([0-9]+) failed", stdout)
             pass_all = len(failed) == 0
             failed = int(failed[0]) if not pass_all else 0
-            return failed
+            result.fitness = failed
         else:
-            raise ParseError
+            result.status = 'PARSE_ERROR'
 
 class MyLineProgram(LineProgram, MyProgram):
     pass

--- a/pyggi/base/__init__.py
+++ b/pyggi/base/__init__.py
@@ -1,4 +1,4 @@
 from .edit import AbstractEdit
 from .patch import Patch
-from .program import AbstractProgram, AbstractEngine, StatusCode, ParseError
+from .program import AbstractProgram, AbstractEngine, RunResult
 from .algorithm import Algorithm

--- a/pyggi/base/program.py
+++ b/pyggi/base/program.py
@@ -20,13 +20,12 @@ from distutils.dir_util import copy_tree
 from .. import PYGGI_DIR
 from ..utils import Logger, weighted_choice
 
-class StatusCode(enum.Enum):
-    NORMAL = 'NORMAL'
-    TIME_OUT = 'TIME_OUT'
-    PARSE_ERROR = 'PARSE_ERR'
-
-class ParseError(Exception):
-    pass
+class RunResult:
+    def __init__(self, status='error', fitness=None):
+        self.status = status
+        self.fitness = fitness
+    def __str__(self):
+        return '<{} {}>'.format(self.__class__.__name__, str(vars(self))[1:-1])
 
 class AbstractEngine(ABC):
     @classmethod
@@ -66,7 +65,6 @@ class AbstractProgram(ABC):
     CONFIG_FILE_NAME = '.pyggi.config'
     TMP_DIR = os.path.join(PYGGI_DIR, 'tmp_variants')
     SAVE_DIR = os.path.join(PYGGI_DIR, 'saved_variants')
-    Result = collections.namedtuple("Result", 'status_code elapsed_time stdout stderr')
 
     def __init__(self, path, config=None):
         self.timestamp = str(int(time.time()))
@@ -274,45 +272,29 @@ class AbstractProgram(ABC):
             start = time.time()
             stdout, stderr = sprocess.communicate(timeout=timeout)
             end = time.time()
-            result = self.__class__.Result(status_code=StatusCode.NORMAL,
-                            elapsed_time=(end - start),
-                            stdout=stdout.decode("ascii"),
-                            stderr=stderr.decode("ascii"))
+            return (sprocess.returncode, stdout.decode("ascii"), stderr.decode("ascii"), end-start)
         except subprocess.TimeoutExpired:
             sprocess.kill()
-            result = self.__class__.Result(status_code=StatusCode.TIME_OUT,
-                            elapsed_time=None,
-                            stdout=None,
-                            stderr=None)
-        os.chdir(cwd)
-        return result
+            return (None, None, None, None)
+        finally:
+            os.chdir(cwd)
 
-    def run(self, timeout=15):
-        """
-        Run the test script of the temporary variant
-
-        :param float timeout: The time limit of test run (unit: seconds)
-        :return: The fitness value of the patch
-        """
-        return self.exec_cmd(self.test_command, timeout)
-
-    def compute_fitness(self, elapsed_time, stdout, stderr):
+    def compute_fitness(self, result, return_code, stdout, stderr, elapsed_time):
         try:
-            return float(stdout.strip())
+            result.fitness = float(stdout.strip())
         except:
-            raise ParseError
+            result.status = 'PARSE_ERROR'
 
     def evaluate_patch(self, patch, timeout=15):
         # apply + run
         self.apply(patch)
-        result = self.run(timeout)
-        if result.status_code == StatusCode.TIME_OUT:
-            return StatusCode.TIME_OUT, None
-        try:
-            fitness = self.compute_fitness(result.elapsed_time, result.stdout, result.stderr)
-        except ParseError:
-            return StatusCode.PARSE_ERROR, None
-        return StatusCode.NORMAL, fitness
+        return_code, stdout, stderr, elapsed_time = self.exec_cmd(self.test_command, timeout)
+        if return_code is None: # timeout
+            return RunResult('TIMEOUT')
+        else:
+            result = RunResult('SUCCESS', None)
+            self.compute_fitness(result, return_code, stdout, stderr, elapsed_time)
+            return result
 
     def diff(self, patch) -> str:
         """

--- a/pyggi/base/program.py
+++ b/pyggi/base/program.py
@@ -21,7 +21,7 @@ from .. import PYGGI_DIR
 from ..utils import Logger, weighted_choice
 
 class RunResult:
-    def __init__(self, status='error', fitness=None):
+    def __init__(self, status, fitness=None):
         self.status = status
         self.fitness = fitness
     def __str__(self):
@@ -294,6 +294,7 @@ class AbstractProgram(ABC):
         else:
             result = RunResult('SUCCESS', None)
             self.compute_fitness(result, return_code, stdout, stderr, elapsed_time)
+            assert not (result.status == 'SUCCESS' and result.fitness is None)
             return result
 
     def diff(self, patch) -> str:

--- a/test/test_patch.py
+++ b/test/test_patch.py
@@ -1,5 +1,5 @@
 import pytest
-from pyggi.base import Patch, StatusCode
+from pyggi.base import Patch
 from pyggi.line import LineProgram
 from pyggi.line import LineDeletion, LineMoving, LineInsertion
 
@@ -68,13 +68,13 @@ class TestPatch(object):
 
     def test_run_test(self, setup):
         patch, program = setup
-        status_code, fitness = program.evaluate_patch(patch)
+        run = program.evaluate_patch(patch)
 
         assert len(patch) > 0
-        if status_code == StatusCode.NORMAL:
-            assert fitness is not None
+        if run.status == 'SUCCESS':
+            assert run.fitness is not None
         else:
-            assert fitness is None
+            assert run.fitness is None
 
     def test_remove(self, setup):
         patch, program = setup


### PR DESCRIPTION
In the present version of PyGGI patch evaluation returns a couple for the status and fitness, e.g.,
```
status_code, fitness = self.program.evaluate_patch(empty_patch, timeout=timeout)
```

My issue is that `status_code` is an enum, and as such not easily extensible.
In my use case possible patch statuses include "compiler error", "compiler timeout", "wrong result", "no result", "crash", "instance timeout", "budget timeout", in addition to PyGGI's "timeout", "normal", and "parse error". For statistical purposes I need to easily access these statuses.

Because PyGGI's `fitness` is expected to be `None` when the status code is not `Normal`, it is possible to use that field to propagate the real error. That is, instead of returning `(TIME_OUT, None)`, I can get my program to return `(TIME_OUT, "COMPILER_TIMEOUT")` or `(TIME_OUT, "BUDGET_TIMEOUT")`, which is manageable but unsatisfactory.

This patch replaces the StatusCode enum with the RunResult class, to enable programs to freely specify status codes, and to avoid hiding the additional statuses in the `fitness` field.
It also has the following minor changes:
- the ParseError exception, only used between `compute_fitness()` and `evaluate_patch()` functions, is removed;
- the Result named tuple, only used between `exec_cmd()` and `evaluate_patch()` functions, is removed in favour of an standard unnamed tuple;
- the return code of executed commands is now accessible in `compute_fitness()` functions.