### PR TITLE
Fix/misc

### DIFF
--- a/pyggi/algorithms/local_search.py
+++ b/pyggi/algorithms/local_search.py
@@ -106,6 +106,8 @@ class LocalSearch(Algorithm):
             self.program.logger.info("Epoch\tIter\tStatus\tFitness\tPatch")
 
         for cur_epoch in range(1, epoch + 1):
+            # Reset Search
+            self.setup()
             cur_result = {}
             best_patch = empty_patch
             best_fitness = original_fitness

--- a/pyggi/base/patch.py
+++ b/pyggi/base/patch.py
@@ -26,7 +26,7 @@ class Patch:
         return len(self.edit_list)
 
     def __eq__(self, other):
-        return self.edit_list == other.edit_list
+        return isinstance(other, Patch) and self.edit_list == other.edit_list
 
     def clone(self):
         """

--- a/pyggi/base/program.py
+++ b/pyggi/base/program.py
@@ -162,9 +162,10 @@ class AbstractProgram(ABC):
         return self.engines[file_name].get_source(self, file_name, index)
 
     def random_file(self, engine=None):
-        files = self.target_files
         if engine:
-            files = list(filter(lambda f: self.engines[f] == engine, files))
+            files = [f for f in self.target_files if issubclass(self.engines[f], engine)]
+        else:
+            files = self.target_files
         return random.choice(files)
 
     def random_target(self, target_file=None, method="random"):

--- a/pyggi/line/__init__.py
+++ b/pyggi/line/__init__.py
@@ -1,2 +1,2 @@
+from .engine import AbstractLineEngine, LineEngine
 from .line import LineProgram, LineReplacement, LineInsertion, LineDeletion, LineMoving
-from .engine import LineEngine

--- a/pyggi/line/line.py
+++ b/pyggi/line/line.py
@@ -2,7 +2,7 @@ import os
 import random
 from abc import abstractmethod
 from ..base import AbstractProgram, AbstractEdit
-from .engine import LineEngine
+from . import AbstractLineEngine, LineEngine
 
 class LineProgram(AbstractProgram):
     @classmethod
@@ -29,7 +29,7 @@ class LineReplacement(LineEdit):
     @classmethod
     def create(cls, program, target_file=None, ingr_file=None, method='random'):
         if target_file is None:
-            target_file = program.random_file()
+            target_file = program.random_file(AbstractLineEngine)
         if ingr_file is None:
             ingr_file = program.random_file(engine=program.engines[target_file])
         assert program.engines[target_file] == program.engines[ingr_file]

--- a/pyggi/line/line.py
+++ b/pyggi/line/line.py
@@ -84,7 +84,10 @@ class LineMoving(LineEdit):
     def apply(self, program, new_contents, modification_points):
         engine = program.engines[self.target[0]]
         engine.do_insert(program, self, new_contents, modification_points)
-        return engine.do_delete(program, self, new_contents, modification_points)
+        self.target, self.ingredient = self.ingredient, self.target
+        return_code = engine.do_delete(program, self, new_contents, modification_points)
+        self.target, self.ingredient = self.ingredient, self.target
+        return return_code
 
     @classmethod
     def create(cls, program, target_file=None, ingr_file=None, direction='before', method='random'):

--- a/pyggi/tree/tree.py
+++ b/pyggi/tree/tree.py
@@ -94,7 +94,10 @@ class StmtMoving(TreeEdit):
     def apply(self, program, new_contents, modification_points):
         engine = program.engines[self.target[0]]
         engine.do_insert(program, self, new_contents, modification_points)
-        return engine.do_delete(program, self, new_contents, modification_points)
+        self.target, self.ingredient = self.ingredient, self.target
+        return_code = engine.do_delete(program, self, new_contents, modification_points)
+        self.target, self.ingredient = self.ingredient, self.target
+        return return_code
 
     @classmethod
     def create(cls, program, target_file=None, ingr_file=None, direction=None, method='random'):

--- a/pyggi/tree/tree.py
+++ b/pyggi/tree/tree.py
@@ -3,7 +3,7 @@ import ast
 import astor
 import random
 from abc import abstractmethod
-from . import AstorEngine, XmlEngine
+from . import AbstractTreeEngine, AstorEngine, XmlEngine
 from ..base import AbstractProgram, AbstractEdit
 from ..utils import get_file_extension
 
@@ -39,7 +39,7 @@ class StmtReplacement(TreeEdit):
     @classmethod
     def create(cls, program, target_file=None, ingr_file=None, method='random'):
         if target_file is None:
-            target_file = program.random_file()
+            target_file = program.random_file(AbstractTreeEngine)
         if ingr_file is None:
             ingr_file = program.random_file(engine=program.engines[target_file])
         assert program.engines[target_file] == program.engines[ingr_file]
@@ -60,7 +60,7 @@ class StmtInsertion(TreeEdit):
     @classmethod
     def create(cls, program, target_file=None, ingr_file=None, direction=None, method='random'):
         if target_file is None:
-            target_file = program.random_file()
+            target_file = program.random_file(AbstractTreeEngine)
         if ingr_file is None:
             ingr_file = program.random_file(engine=program.engines[target_file])
         assert program.engines[target_file] == program.engines[ingr_file]
@@ -81,7 +81,7 @@ class StmtDeletion(TreeEdit):
     @classmethod
     def create(cls, program, target_file=None, method='random'):
         if target_file is None:
-            target_file = program.random_file()
+            target_file = program.random_file(AbstractTreeEngine)
         return cls(program.random_target(target_file, method))
 
 class StmtMoving(TreeEdit):
@@ -102,7 +102,7 @@ class StmtMoving(TreeEdit):
     @classmethod
     def create(cls, program, target_file=None, ingr_file=None, direction=None, method='random'):
         if target_file is None:
-            target_file = program.random_file()
+            target_file = program.random_file(AbstractTreeEngine)
         if ingr_file is None:
             ingr_file = program.random_file(engine=program.engines[target_file])
         assert program.engines[target_file] == program.engines[ingr_file]

--- a/pyggi/tree/xml_engine.py
+++ b/pyggi/tree/xml_engine.py
@@ -146,9 +146,12 @@ class XmlEngine(AbstractTreeEngine):
         for i, child in enumerate(parent):
             if child == target:
                 tmp = copy.deepcopy(ingredient)
-                tmp.tail = None
                 if op.direction == 'after':
+                    tmp.tail = child.tail
+                    child.tail = None
                     i += 1
+                else:
+                    tmp.tail = None
                 parent.insert(i, tmp)
                 break
         else:


### PR DESCRIPTION
Few completely independent bug fixes for PyGGI.

- **fix Patch comparison**
  In a comparison between a `Patch` and another type of object, `AttributeError` was raised instead of returning `False`.
- **fix tail not being set up correctly**
  When inserting at the end a block, the tailing text (e.g., the closing bracket "`}`") was sometimes inserted at the wrong place.
- **fix some children not being killed**
  When the main child process spawn more processes (e.g., when starting a shell), descendant were not killed when the parent times out.
- **fix move edits**
  During a move, the target was deleted instead of the ingredient.
  The bug would have been far more evident if the `do_***` methods took the target and ingredient explicitly instead of using the edit directly.
- **fix search never being reset**
  In the `repair_java.py` example, the `setup()` method was only called at the very beginning and not at every epoch, making the tabu list never reset. With sufficient time, the search completely would lock down in an infinite loop as no more edit can be created.
- **fix edits being created on incompatible files**
  When considering multiple files using different engines, edits could be created targeting material on unsupported files.

